### PR TITLE
Fix http 404 when BASE_PATH is assigned

### DIFF
--- a/server.py
+++ b/server.py
@@ -7,15 +7,6 @@ from dateutil import parser
 from concurrent.futures import wait, ALL_COMPLETED
 from flask_executor import Executor
 
-app = Flask(__name__)
-executor = Executor(app)
-
-# Logging headers
-handler = logging.StreamHandler(sys.stdout)
-handler.setFormatter(logging.Formatter(
-    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
-app.logger.addHandler(handler)
-app.logger.setLevel(logging.DEBUG)
 
 # Global vars
 # Colors:  https://materializecss.com/color.html
@@ -29,9 +20,26 @@ GIT_BRANCH  = os.environ["GIT_BRANCH"]
 HS_VERSION  = "v0.20.0"
 DEBUG_STATE = False
 
+
+static_url_path = '/static'
+if BASE_PATH != '':
+    static_url_path = BASE_PATH + static_url_path
+
+app = Flask(__name__, static_url_path=static_url_path)
+executor = Executor(app)
+
+# Logging headers
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter(
+    '%(asctime)s - %(name)s - %(levelname)s - %(message)s'))
+app.logger.addHandler(handler)
+app.logger.setLevel(logging.DEBUG)
+
+
 @app.route('/')
 @app.route(BASE_PATH+'/')
 @app.route('/overview')
+@app.route(BASE_PATH+'/overview')
 def overview_page():
     # If the API key fails, redirect to the settings page:
     if not helper.key_test(): return redirect(BASE_PATH+url_for('settings_page'))
@@ -42,6 +50,7 @@ def overview_page():
         COLOR_BTN   = COLOR_BTN
     )
 
+@app.route(BASE_PATH+'/machines', methods=('GET', 'POST'))
 @app.route('/machines', methods=('GET', 'POST'))
 def machines_page():
     # If the API key fails, redirect to the settings page:
@@ -55,6 +64,7 @@ def machines_page():
         COLOR_BTN   = COLOR_BTN
     )
 
+@app.route(BASE_PATH+'/users', methods=('GET', 'POST'))
 @app.route('/users', methods=('GET', 'POST'))
 def users_page():
     # If the API key fails, redirect to the settings page:
@@ -68,6 +78,7 @@ def users_page():
         COLOR_BTN   = COLOR_BTN
     )
 
+@app.route(BASE_PATH+'/settings', methods=('GET', 'POST'))
 @app.route('/settings', methods=('GET', 'POST'))
 def settings_page():
     url     = headscale.get_url()
@@ -92,6 +103,7 @@ def settings_page():
 # Headscale API Key Endpoints
 ########################################################################################
 
+@app.route(BASE_PATH+'/api/test_key', methods=('GET', 'POST'))
 @app.route('/api/test_key', methods=('GET', 'POST'))
 def test_key_page():
     api_key    = headscale.get_api_key()
@@ -132,6 +144,7 @@ def test_key_page():
     message = json.dumps(key_info)
     return message
 
+@app.route(BASE_PATH+'/api/save_key', methods=['POST'])
 @app.route('/api/save_key', methods=['POST'])
 def save_key_page():
     json_response = request.get_json()
@@ -157,6 +170,7 @@ def save_key_page():
 ########################################################################################
 # Machine API Endpoints
 ########################################################################################
+@app.route(BASE_PATH+'/api/update_route', methods=['POST'])
 @app.route('/api/update_route', methods=['POST'])
 def update_route_page():
     json_response = request.get_json()
@@ -167,6 +181,7 @@ def update_route_page():
 
     return headscale.update_route(url, api_key, route_id, current_state)
 
+@app.route(BASE_PATH+'/api/machine_information', methods=['POST'])
 @app.route('/api/machine_information', methods=['POST'])
 def machine_information_page():
     json_response = request.get_json()
@@ -176,6 +191,7 @@ def machine_information_page():
 
     return headscale.get_machine_info(url, api_key, machine_id)
 
+@app.route(BASE_PATH+'/api/delete_machine', methods=['POST'])
 @app.route('/api/delete_machine', methods=['POST'])
 def delete_machine_page():
     json_response = request.get_json()
@@ -185,6 +201,7 @@ def delete_machine_page():
 
     return headscale.delete_machine(url, api_key, machine_id)
 
+@app.route(BASE_PATH+'/api/rename_machine', methods=['POST'])
 @app.route('/api/rename_machine', methods=['POST'])
 def rename_machine_page():
     json_response = request.get_json()
@@ -195,6 +212,7 @@ def rename_machine_page():
 
     return headscale.rename_machine(url, api_key, machine_id, new_name)
 
+@app.route(BASE_PATH+'/api/move_user', methods=['POST'])
 @app.route('/api/move_user', methods=['POST'])
 def move_user_page():
     json_response = request.get_json()
@@ -205,6 +223,7 @@ def move_user_page():
 
     return headscale.move_user(url, api_key, machine_id, new_user)
 
+@app.route(BASE_PATH+'/api/set_machine_tags', methods=['POST'])
 @app.route('/api/set_machine_tags', methods=['POST'])
 def set_machine_tags():
     json_response = request.get_json()
@@ -215,6 +234,7 @@ def set_machine_tags():
 
     return headscale.set_machine_tags(url, api_key, machine_id, machine_tags)
 
+@app.route(BASE_PATH+'/api/register_machine', methods=['POST'])
 @app.route('/api/register_machine', methods=['POST'])
 def register_machine():
     json_response = request.get_json()
@@ -228,6 +248,7 @@ def register_machine():
 ########################################################################################
 # User API Endpoints
 ########################################################################################
+@app.route(BASE_PATH+'/api/rename_user', methods=['POST'])
 @app.route('/api/rename_user', methods=['POST'])
 def rename_user_page():
     json_response = request.get_json()
@@ -238,6 +259,7 @@ def rename_user_page():
 
     return headscale.rename_user(url, api_key, old_name, new_name)
 
+@app.route(BASE_PATH+'/api/add_user', methods=['POST'])
 @app.route('/api/add_user', methods=['POST'])
 def add_user():
     json_response  = json.dumps(request.get_json())
@@ -246,6 +268,7 @@ def add_user():
 
     return headscale.add_user(url, api_key, json_response)
 
+@app.route(BASE_PATH+'/api/delete_user', methods=['POST'])
 @app.route('/api/delete_user', methods=['POST'])
 def delete_user():
     json_response  = request.get_json()
@@ -255,6 +278,7 @@ def delete_user():
 
     return headscale.delete_user(url, api_key, user_name)
 
+@app.route(BASE_PATH+'/api/get_users', methods=['POST'])
 @app.route('/api/get_users', methods=['POST'])
 def get_users_page():
     url           = headscale.get_url()
@@ -265,6 +289,7 @@ def get_users_page():
 ########################################################################################
 # Pre-Auth Key API Endpoints
 ########################################################################################
+@app.route(BASE_PATH+'/api/add_preauth_key', methods=['POST'])
 @app.route('/api/add_preauth_key', methods=['POST'])
 def add_preauth_key():
     json_response  = json.dumps(request.get_json())
@@ -273,6 +298,7 @@ def add_preauth_key():
 
     return headscale.add_preauth_key(url, api_key, json_response)
 
+@app.route(BASE_PATH+'/api/expire_preauth_key', methods=['POST'])
 @app.route('/api/expire_preauth_key', methods=['POST'])
 def expire_preauth_key():
     json_response  = json.dumps(request.get_json())
@@ -281,6 +307,7 @@ def expire_preauth_key():
 
     return headscale.expire_preauth_key(url, api_key, json_response)
 
+@app.route(BASE_PATH+'/api/build_preauthkey_table', methods=['POST'])
 @app.route('/api/build_preauthkey_table', methods=['POST'])
 def build_preauth_key_table():
     json_response  = request.get_json()


### PR DESCRIPTION
Below is the nginx reverse proxy configuration which I used to test.

location /admin {
        proxy_pass http://127.0.0.1:5000/admin;
        proxy_http_version 1.1;
        proxy_set_header Host $server_name;
        proxy_buffering off;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;

        auth_basic "Administrator's Area";
        auth_basic_user_file /etc/nginx/htpasswd;
    }
