### PR TITLE
Read OIDC_CLOCK_SKEW from ENV to resolve #75

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,8 @@ ENV BASIC_AUTH_PASS=""
 ENV OIDC_AUTH_URL=https://localhost
 ENV OIDC_CLIENT_ID=Headscale-WebUI
 ENV OIDC_CLIENT_SECRET=secret
+# set do default value: https://flask-oidc.readthedocs.io/en/latest/
+ENV OIDC_CLOCK_SKEW=60
 
 # Jenkins build args
 ARG GIT_COMMIT_ARG=""

--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@
     * Enable / disable routes and exit nodes
     * Add and delete machine tags
 7.  Basic and OIDC Authentication
-    * OIDC Authentication tested with Authelia and Keycloak
+    -   OIDC Authentication tested with AzureAD, Authelia and Keycloak
+        -   AzureAD needs OIDC_CLOCK_SKEW set to 360
 8.  Change your color theme! See MaterializeCSS Documentation for Colors for examples.
 9.  Search your machines and users.
     * Machines have tags you can use to filter search:

--- a/server.py
+++ b/server.py
@@ -44,11 +44,12 @@ if AUTH_TYPE == "oidc":
     # https://github.com/steinarvk/flask_oidc_demo 
     app.logger.info("Loading OIDC libraries and configuring app...")
 
-    DOMAIN_NAME    = os.environ["DOMAIN_NAME"]
-    BASE_PATH      = os.environ["SCRIPT_NAME"] if os.environ["SCRIPT_NAME"] != "/" else ""
-    OIDC_SECRET    = os.environ["OIDC_CLIENT_SECRET"]
-    OIDC_CLIENT_ID = os.environ["OIDC_CLIENT_ID"]
-    OIDC_AUTH_URL  = os.environ["OIDC_AUTH_URL"]
+    DOMAIN_NAME     = os.environ["DOMAIN_NAME"]
+    BASE_PATH       = os.environ["SCRIPT_NAME"] if os.environ["SCRIPT_NAME"] != "/" else ""
+    OIDC_SECRET     = os.environ["OIDC_CLIENT_SECRET"]
+    OIDC_CLIENT_ID  = os.environ["OIDC_CLIENT_ID"]
+    OIDC_AUTH_URL   = os.environ["OIDC_AUTH_URL"]
+    OIDC_CLOCK_SKEW = float(os.environ["OIDC_CLOCK_SKEW"])
 
     # Construct client_secrets.json:
     response = requests.get(str(OIDC_AUTH_URL))
@@ -86,7 +87,8 @@ if AUTH_TYPE == "oidc":
         'OIDC_USER_INFO_ENABLED': True,
         'OIDC_OPENID_REALM': 'Headscale-WebUI',
         'OIDC_SCOPES': ['openid', 'profile', 'email'],
-        'OIDC_INTROSPECTION_AUTH_METHOD': 'client_secret_post'
+        'OIDC_INTROSPECTION_AUTH_METHOD': 'client_secret_post',
+        'OIDC_CLOCK_SKEW': OIDC_CLOCK_SKEW,
     })
     from flask_oidc import OpenIDConnect
     oidc = OpenIDConnect(app)


### PR DESCRIPTION
To fix the 401 Not Authorized (Token issued in the past) Error during OIDC login with Azure AD disscussed in #75 a OIDC_CLOCK_SKEW can be set as an environment variable and gets passed to Flask-OIDC.

More Information:
- https://stackoverflow.com/a/56951662
- https://flask-oidc.readthedocs.io/en/latest/